### PR TITLE
user current call uses wrong lookup hashmap

### DIFF
--- a/src/org/ohmage/servlet/UserServlet.java
+++ b/src/org/ohmage/servlet/UserServlet.java
@@ -664,7 +664,7 @@ public class UserServlet extends OhmageServlet {
                 // If the version isn't present...
                 if(streamRef.getVersion() == null) {
                     // Attempt to lookup the value.
-                    Long version = surveyLookup.get(streamRef.getSchemaId());
+                    Long version = streamLookup.get(streamRef.getSchemaId());
 
                     // If the lookup failed, perform the actual lookup from the
                     // database.


### PR DESCRIPTION
This means it will always go to the db even if the stream exists in the map
