### PR TITLE
updated default observer definitions

### DIFF
--- a/db/sql/settings/default_observers.sql
+++ b/db/sql/settings/default_observers.sql
@@ -78,7 +78,7 @@ INSERT INTO
             true,
             true,
             false,
-            '{"type":"object","doc":"Prompt interaction.","schema":[{"name":"id","doc":"The promptId.","type":"string"},{"name":"type","doc":"The prompt type.","type":"string"},{"name":"status","doc":"Status information about the activity. Either ON or OFF.","type":"string"}]}'
+            '{"type":"object","doc":"Prompt interaction.","fields":[{"name":"id","doc":"The promptId.","type":"string"},{"name":"type","doc":"The prompt type.","type":"string"},{"name":"status","doc":"Status information about the activity. Either ON or OFF.","type":"string"}]}'
         ),
         (
             @analytics_trigger_stream_id,
@@ -88,7 +88,7 @@ INSERT INTO
             true,
             true,
             false,
-            '{"type":"object","doc":"Trigger interaction.","schema":[{"name":"action","doc":"The action that was currently applied to the trigger. One of delete, add, trigger, update, or ignore.","type":"string"},{"name":"type","doc":"Trigger type.","type":"string"},{"name":"count","doc":"Current number of triggers for this campaign and trigger type set up in the system.","type":"number"},{"name":"campaign","doc":"The campaign urn to which this trigger belongs.","type":"string"}]}'
+            '{"type":"object","doc":"Trigger interaction.","fields":[{"name":"action","doc":"The action that was currently applied to the trigger. One of delete, add, trigger, update, or ignore.","type":"string"},{"name":"type","doc":"Trigger type.","type":"string"},{"name":"count","doc":"Current number of triggers for this campaign and trigger type set up in the system.","type":"number"},{"name":"campaign","doc":"The campaign urn to which this trigger belongs.","type":"string"}]}'
         ),
         (
             @logprobe_activity_stream_id,
@@ -98,7 +98,7 @@ INSERT INTO
             true,
             true,
             false,
-            '{"type":"object","doc":"Activity interaction.","schema":[{"name":"activity","doc":"The class name of the activity.","type":"string"},{"name":"status","doc":"Status information about the activity. Either ON or OFF.","type":"string"}]}'
+            '{"type":"object","doc":"Activity interaction.","fields":[{"name":"activity","doc":"The class name of the activity.","type":"string"},{"name":"status","doc":"Status information about the activity. Either ON or OFF.","type":"string"}]}'
         ),
         (
             @logprobe_log_stream_id,
@@ -108,7 +108,7 @@ INSERT INTO
             true,
             true,
             false,
-            '{"type":"object","doc":"log message.","schema":[{"name":"level","doc":"Log level. One of error, warning, info, debug, or verbose.","type":"string"},{"name":"tag","doc":"Used to identify the source of a log message. It usually identifies the class or activity where the log call occurs.","type":"string"},{"name":"message","doc":"The message you would like logged.","type":"string"}]}'
+            '{"type":"object","doc":"log message.","fields":[{"name":"level","doc":"Log level. One of error, warning, info, debug, or verbose.","type":"string"},{"name":"tag","doc":"Used to identify the source of a log message. It usually identifies the class or activity where the log call occurs.","type":"string"},{"name":"message","doc":"The message you would like logged.","type":"string"}]}'
         ),
         (
             @logprobe_network_stream_id,
@@ -118,7 +118,7 @@ INSERT INTO
             true,
             true,
             false,
-            '{"type":"object","doc":"Network information.","schema":[{"name":"context","doc":"Class name of the context which started the call to the network.","type":"string"},{"name":"resource","doc":"Name of the resource requested","type":"string"},{"name":"network_state","doc":"upload or download","type":"string"},{"name":"length","doc":"Number of bytes transmitted","type":"number"}]}'
+            '{"type":"object","doc":"Network information.","fields":[{"name":"context","doc":"Class name of the context which started the call to the network.","type":"string"},{"name":"resource","doc":"Name of the resource requested","type":"string"},{"name":"network_state","doc":"upload or download","type":"string"},{"name":"length","doc":"Number of bytes transmitted","type":"number"}]}'
         ),
         (
             @logprobe_service_stream_id,
@@ -128,7 +128,7 @@ INSERT INTO
             true,
             true,
             false,
-            '{"type":"object","doc":"Service interaction.","schema":[{"name":"service","doc":"The class name of the service.","type":"string"},{"name":"status","doc":"Status information about the service. Either ON or OFF.","type":"string"}]}'
+            '{"type":"object","doc":"Service interaction.","fields":[{"name":"service","doc":"The class name of the service.","type":"string"},{"name":"status","doc":"Status information about the service. Either ON or OFF.","type":"string"}]}'
         ),
         (
             @logprobe_widget_stream_id,
@@ -138,7 +138,7 @@ INSERT INTO
             true,
             true,
             false,
-            '{"type":"object","doc":"Widget interaction.","schema":[{"name":"id","doc":"The id of the view which produced this event.","type":"number"},{"name":"name","doc":"The human readable name of the view which produced this event. Will read the getContentDescription() of the view.","type":"string"},{"name":"extra","doc":"Extra information supplied for this interaction.","optional":true,"type":"string"}]}'
+            '{"type":"object","doc":"Widget interaction.","fields":[{"name":"id","doc":"The id of the view which produced this event.","type":"number"},{"name":"name","doc":"The human readable name of the view which produced this event. Will read the getContentDescription() of the view.","type":"string"},{"name":"extra","doc":"Extra information supplied for this interaction.","optional":true,"type":"string"}]}'
         ),
         (
             @mobility_regular_stream_id,
@@ -148,7 +148,7 @@ INSERT INTO
             true,
             true,
             NULL,
-            '{"type":"object","doc":"Only requires the user\'s mode.","schema":[{"name":"mode","type":"string","doc":"The user\'s mode."}]}'
+            '{"type":"object","doc":"Only requires the user\'s mode.","fields":[{"name":"mode","type":"string","doc":"The user\'s mode."}]}'
         ),
         (
             @mobility_error_stream_id,
@@ -158,7 +158,7 @@ INSERT INTO
             true,
             true,
             NULL,
-            '{"type":"object","doc":"Only requires the user\'s mode, which must be \\"error\\".","schema":[{"name":"mode","type":"string","doc":"The user\'s mode."}]}'
+            '{"type":"object","doc":"Only requires the user\'s mode, which must be \\"error\\".","fields":[{"name":"mode","type":"string","doc":"The user\'s mode."}]}'
         ),
         (
             @mobility_extended_stream_id,
@@ -168,7 +168,7 @@ INSERT INTO
             true,
             true,
             NULL,
-            '{"type":"object","doc":"Contains the user\'s mode as well as the sensor data.","schema":[{"name":"mode","type":"string","doc":"The user\'s mode."},{"name":"speed","type":"number","doc":"The user\'s speed in the last minute.","optional":true},{"name":"accel_data","type":"array","schema":{"type":"object","doc":"A single accelerometer reading.","schema":[{"name":"x","type":"number","doc":"The x-component of the accelerometer reading."},{"name":"y","type":"number","doc":"The y-component of the accelerometer reading."},{"name":"z","type":"number","doc":"The z-component of the accelerometer reading."}]},"doc":"An array of the accelerometer readings over the last minute."},{"name":"wifi_data","type":"object","doc":"A WiFi reading from the last minute.","schema":[{"name":"time","type":"number","doc":"The time this data was recorded."},{"name":"timezone","type":"string","doc":"The time zone of the device when this data was recorded."},{"name":"scan","type":"array","schema":{"type":"object","doc":"A single access point\'s information.","schema":[{"name":"ssid","type":"string","doc":"The access point\'s SSID."},{"name":"strength","type":"number","doc":"The strength of the signal from the access point."}]},"doc":"The scan of WiFi information."}]}]}'
+            '{"type":"object","doc":"Contains the user\'s mode as well as the sensor data.","fields":[{"name":"mode","type":"string","doc":"The user\'s mode."},{"name":"speed","type":"number","doc":"The user\'s speed in the last minute.","optional":true},{"name":"accel_data","type":"array","constType":{"type":"object","doc":"A single accelerometer reading.","fields":[{"name":"x","type":"number","doc":"The x-component of the accelerometer reading."},{"name":"y","type":"number","doc":"The y-component of the accelerometer reading."},{"name":"z","type":"number","doc":"The z-component of the accelerometer reading."}]},"doc":"An array of the accelerometer readings over the last minute."},{"name":"wifi_data","type":"object","doc":"A WiFi reading from the last minute.","fields":[{"name":"time","type":"number","doc":"The time this data was recorded."},{"name":"timezone","type":"string","doc":"The time zone of the device when this data was recorded."},{"name":"scan","type":"array","constType":{"type":"object","doc":"A single access point\'s information.","fields":[{"name":"ssid","type":"string","doc":"The access point\'s SSID."},{"name":"strength","type":"number","doc":"The strength of the signal from the access point."}]},"doc":"The scan of WiFi information."}]}]}'
         );
 
 -- Get the database IDs for the streams.


### PR DESCRIPTION
in order to be compatible with the latest concordia version modified in ac38d0dfc4c16809f7587f8677282806464159f9. @joshuaselsky -- could you take a look at this and merge if you agree that it resolves the issue? currently, someone setting up a ohmage server with the latest master/2.16 commit and the db scripts would create definitions not compatible with the concordia version in use.
