### PR TITLE
per RFC2231 filename in download should be encapsulated via quotes. clos...

### DIFF
--- a/src/org/ohmage/request/document/DocumentReadContentsRequest.java
+++ b/src/org/ohmage/request/document/DocumentReadContentsRequest.java
@@ -197,7 +197,7 @@ public class DocumentReadContentsRequest extends UserRequest {
 				// Set the type and force the browser to download it as the 
 				// last step before beginning to stream the response.
 				httpResponse.setContentType("ohmage/document");
-				httpResponse.setHeader("Content-Disposition", "attachment; filename=" + documentName);
+				httpResponse.setHeader("Content-Disposition", "attachment; filename=\"" + documentName + "\"");
 				
 				// If available, set the token.
 				if(getUser() != null) {


### PR DESCRIPTION
...es #852