### PR TITLE
app_name from preference table

### DIFF
--- a/db/migration/V7__2.18_add_app_name_to_preferences.sql
+++ b/db/migration/V7__2.18_add_app_name_to_preferences.sql
@@ -1,0 +1,8 @@
+-- ----------------------------------------------------------------------
+-- Inserts a default preference key so as not to be statefully reliant on
+-- the compiled war file.
+-------------------------------------------------------------------------
+
+INSERT INTO preference (p_key, p_value) VALUES 
+  ('application_name', 'ohmage')
+    ON DUPLICATE KEY UPDATE p_value=VALUES(p_value);

--- a/src/org/ohmage/cache/PreferenceCache.java
+++ b/src/org/ohmage/cache/PreferenceCache.java
@@ -84,6 +84,7 @@ public final class PreferenceCache extends KeyValueCache {
 	
 	// Build-specific information.
 	public static final String KEY_APPLICATION_NAME = "application.name";
+	public static final String SQL_KEY_APPLICATION_NAME = "application_name";
 	public static final String KEY_APPLICATION_VERSION = "application.version";
 	public static final String KEY_APPLICATION_BUILD = "application.build";
 	
@@ -229,9 +230,17 @@ public final class PreferenceCache extends KeyValueCache {
 		if((getLastUpdateTimestamp() + getUpdateFrequency()) <= System.currentTimeMillis()) {
 			refreshMap();
 		}
+
+		if(KEY_APPLICATION_NAME.equals(key)) {
+		  try {
+		  	return super.lookup(SQL_KEY_APPLICATION_NAME); 
+		  }
+		  catch(CacheMissException e) {
+		  	return getSystemProperty(key);
+		  }
+		}
 		
-		if(KEY_APPLICATION_NAME.equals(key) ||
-		   KEY_APPLICATION_VERSION.equals(key) ||
+		if(KEY_APPLICATION_VERSION.equals(key) ||
 		   KEY_APPLICATION_BUILD.equals(key)) {
 			return getSystemProperty(key);
 		}


### PR DESCRIPTION
@hongsudt can you glance at this? the migration adds a default value of 'ohmage'. If one deletes the row from the db (or, the row is simply missing!), it maintains the original functionality.