### PR TITLE
add integrated docker builds.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,77 @@
+FROM debian:jessie
+MAINTAINER Steve Nolen <technolengy@gmail.com>
+# Report issues here: https://github.com/ohmage/server
+
+RUN set -x \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get update \
+    && apt-get install -y openjdk-7-jdk ant curl libtcnative-1 netcat git mysql-client\
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# download tomcat
+ENV CATALINA_HOME /usr/local/tomcat
+ENV PATH $CATALINA_HOME/bin:$PATH
+RUN mkdir -p "$CATALINA_HOME"
+WORKDIR $CATALINA_HOME
+ 
+# see https://www.apache.org/dist/tomcat/tomcat-8/KEYS
+RUN gpg --keyserver pool.sks-keyservers.net --recv-keys \
+  05AB33110949707C93A279E3D3EFE6B686867BA6 \
+  07E48665A34DCAFAE522E5E6266191C37C037D42 \
+  47309207D818FFD8DCD3F83F1931D684307A10A5 \
+  541FBE7D8F78B25E055DDEE13C370389288584E7 \
+  61B832AC2F1C5A90F0F9B00A1C506407564C17A3 \
+  713DA88BE50911535FE716F5208B0AB1D63011C7 \
+  79F7026C690BAA50B92CD8B66A3AD3F4F22C4FED \
+  9BA44C2621385CB966EBA586F72C284D731FABEE \
+  A27677289986DB50844682F8ACB77FC2E86E29AC \
+  A9C5DF4D22E99998D9875A5110C01C5A2F6059E7 \
+  DCFD35E0BF8CA7344752DE8B6FB21E8933C60243 \
+  F3A04C595DB5B6A5F1ECA43E3B7BBB100D811BBE \
+  F7DA48BB64BCB84ECBA7EE6935CD23C10D498E23
+ 
+ENV TOMCAT_MAJOR 7
+ENV TOMCAT_VERSION 7.0.67
+ENV TOMCAT_TGZ_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ 
+RUN set -x \
+  && curl -fSL "$TOMCAT_TGZ_URL" -o tomcat.tar.gz \
+  && curl -fSL "$TOMCAT_TGZ_URL.asc" -o tomcat.tar.gz.asc \
+  && gpg --verify tomcat.tar.gz.asc \
+  && tar -xvf tomcat.tar.gz --strip-components=1 \
+  && rm bin/*.bat \
+  && rm tomcat.tar.gz* \
+  && rm -rf /usr/local/tomcat/webapps/ROOT \
+  && rm -rf /usr/local/tomcat/webapps/docs \
+  && rm -rf /usr/local/tomcat/webapps/examples \
+  && rm -rf /usr/local/tomcat/webapps/manager \
+  && rm -rf /usr/local/tomcat/webapps/host-manager
+ 
+#### download flyway (ohmage doesn't do migrations) ####
+WORKDIR /flyway
+ENV FLYWAY_TGZ_URL http://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/3.2.1/flyway-commandline-3.2.1.tar.gz
+RUN set -x \
+    && curl -fSL "$FLYWAY_TGZ_URL" -o flyway.tar.gz \
+    && tar -xvf flyway.tar.gz --strip-components=1 \
+    && rm flyway.tar.gz
+
+WORKDIR /app
+ADD . /app
+RUN cp db/migration/* /flyway/sql/ \
+  && ant clean dist \
+  && cp dist/webapp-ohmage* "$CATALINA_HOME"/webapps/app.war \
+  && cp docker_entrypoint.sh /run.sh \
+  && chmod +x /run.sh \
+  && rm -rf /app
+
+RUN mkdir -p /var/lib/ohmage && ln -s /var/lib/ohmage /ohmage
+RUN useradd -ms /bin/bash ohmage && \
+    chown -R ohmage.ohmage "$CATALINA_HOME" && \
+    chown -R ohmage.ohmage /var/lib/ohmage
+
+EXPOSE 8080
+
+VOLUME /ohmage
+
+CMD ["/run.sh"]

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -e
+
+# use passed env variable or defaults
+DB_HOST=$MYSQL_PORT_3306_TCP_ADDR
+DB_PORT=$MYSQL_PORT_3306_TCP_PORT
+DB_NAME=${DB_NAME:-ohmage}
+DB_USER=${DB_USER:-ohmage}
+DB_PASS=${DB_PASS:-ohmage}
+FQDN=${FQDN:-$HOSTNAME}
+LOG_LEVEL=${LOG_LEVEL:-WARN}
+ESCAPED_PW=${DB_PASS/\&/\\&}
+
+# cat out ohmage.conf
+echo "#
+# DATABASE
+#
+db.driver=com.mysql.jdbc.Driver
+db.jdbcurl=jdbc:mysql://$DB_HOST:$DB_PORT/$DB_NAME?characterEncoding=utf8
+db.username=$DB_USER
+db.password=$ESCAPED_PW
+#
+# LOGGING
+#
+# The root logger 
+log4j.rootLogger=$LOG_LEVEL, stdout
+
+log4j.appender.stdout = org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Threshold = $LOG_LEVEL
+log4j.appender.stdout.Target   = System.out
+log4j.appender.stdout.layout = org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern = %-5p %d [%t][%F:%L] : %m%n
+ 
+log4j.logger.org.ohmage=$LOG_LEVEL
+log4j.logger.org.springframework=$LOG_LEVEL
+log4j.logger.org.ohmage.util.JsonUtils=$LOG_LEVEL
+log4j.logger.org.ohmage.cache.UserBin=$LOG_LEVEL" > /etc/ohmage.conf
+ 
+# cat out flyway.conf
+# note that the placeholders wont be updated at each boot.
+echo "flyway.url=jdbc:mysql://$DB_HOST:$DB_PORT/$DB_NAME
+flyway.user=$DB_USER
+flyway.password=$DB_PASS
+flyway.placeholders.fqdn=$FQDN
+flyway.placeholders.base_dir=/var/lib/ohmage" > /flyway/conf/flyway.conf
+
+# create database stuffz. different depending on linked mysql container.
+echo -n "waiting for mysql to start..."
+while ! nc -w 1 $DB_HOST $DB_PORT &> /dev/null
+do
+  echo -n .
+  sleep 1
+done
+echo 'mysql available.'
+mysql -uroot -p$MYSQL_ENV_MYSQL_ROOT_PASSWORD -h$DB_HOST -P$DB_PORT mysql -e "CREATE DATABASE IF NOT EXISTS $DB_NAME; grant all on $DB_NAME.* to \"$DB_USER\"@\"%\" IDENTIFIED BY \"$DB_PASS\"; FLUSH PRIVILEGES;"
+
+# execute migrations
+/flyway/flyway migrate
+
+# ensure ohmage directory structure exists
+mkdir -p /var/lib/ohmage/audio
+mkdir -p /var/lib/ohmage/audits
+mkdir -p /var/lib/ohmage/documents
+mkdir -p /var/lib/ohmage/images
+mkdir -p /var/lib/ohmage/videos
+chown -R ohmage.ohmage /var/lib/ohmage
+ 
+# start tomcat in foreground
+exec /usr/local/tomcat/bin/catalina.sh run


### PR DESCRIPTION
Adds dockerfile and docker entry script to source. `debian:jessie` is used and `openjdk-7-jre` package (which adds an enormous amount of bloat) in order to provide a fully-compatible container that mimics known stable ohmage production environments.

@hongsudt probably want to pull from this branch before you continue working. this makes docker builds for the ohmage server project much simpler.