### PR TITLE
Fix issues with Chrome downloading files with commas in the filename

### DIFF
--- a/src/org/ohmage/request/audio/AudioReadRequest.java
+++ b/src/org/ohmage/request/audio/AudioReadRequest.java
@@ -148,7 +148,7 @@ public class AudioReadRequest extends UserRequest {
 				
 				httpResponse.setHeader(
 					"Content-Disposition", 
-					"attachment; filename=" + audio.getFileName());
+					"attachment; filename=\"" + audio.getFileName() + "\"");
 				httpResponse.setHeader(
 					"Content-Length", 
 					new Long(audio.getFileSize()).toString());

--- a/src/org/ohmage/request/campaign/CampaignReadRequest.java
+++ b/src/org/ohmage/request/campaign/CampaignReadRequest.java
@@ -571,7 +571,7 @@ public class CampaignReadRequest extends UserRequest {
 				httpResponse
 					.setHeader(
 						"Content-Disposition",
-						"attachment; filename=" + campaign.getName() + ".xml");
+						"attachment; filename=\"" + campaign.getName() + ".xml\"");
 				
 				try {
 					responseText = campaign.getXml();

--- a/src/org/ohmage/request/clazz/ClassRosterReadRequest.java
+++ b/src/org/ohmage/request/clazz/ClassRosterReadRequest.java
@@ -171,7 +171,7 @@ public class ClassRosterReadRequest extends UserRequest {
 			// Set the type and force the browser to download it as the 
 			// last step before beginning to stream the response.
 			httpResponse.setContentType("ohmage/roster");
-			httpResponse.setHeader("Content-Disposition", "attachment; filename=roster.csv");
+			httpResponse.setHeader("Content-Disposition", "attachment; filename=\"roster.csv\"");
 			
 			// If available, set the token.
 			if(getUser() != null) {

--- a/src/org/ohmage/request/image/ImageBatchZipReadRequest.java
+++ b/src/org/ohmage/request/image/ImageBatchZipReadRequest.java
@@ -191,7 +191,7 @@ public class ImageBatchZipReadRequest extends SurveyResponseRequest {
 		// the header to indicate that this will be an attachment.
 		httpResponse.setHeader(
 				"Content-Disposition", 
-				"attachment; filename=images.zip");
+				"attachment; filename=\"images.zip\"");
 		
 		// Create the zip stream to the outside world.
 		ZipOutputStream zipStream = null;

--- a/src/org/ohmage/request/image/ImageZipReadRequest.java
+++ b/src/org/ohmage/request/image/ImageZipReadRequest.java
@@ -106,7 +106,7 @@ public class ImageZipReadRequest extends SurveyResponseRequest {
 		// the header to indicate that this will be an attachment.
 		httpResponse.setHeader(
 				"Content-Disposition", 
-				"attachment; filename=images.zip");
+				"attachment; filename=\"images.zip\"");
 		
 		// Create the zip stream to the outside world.
 		ZipOutputStream zipStream = null;

--- a/src/org/ohmage/request/media/MediaReadRequest.java
+++ b/src/org/ohmage/request/media/MediaReadRequest.java
@@ -180,7 +180,7 @@ public class MediaReadRequest extends UserRequest {
 					// only set content-disposition if media is not video/image/audio
 					if (contentType.startsWith("application") || contentType.startsWith("text"))
 						httpResponse.setHeader("Content-Disposition", 
-								"attachment; filename=" + media.getFileName());
+								"attachment; filename=\"" + media.getFileName() + "\"");
 					
 					httpResponse.setHeader("Content-Length", 
 						new Long(media.getFileSize()).toString());

--- a/src/org/ohmage/request/mobility/MobilityReadCsvRequest.java
+++ b/src/org/ohmage/request/mobility/MobilityReadCsvRequest.java
@@ -271,7 +271,7 @@ public class MobilityReadCsvRequest extends UserRequest {
 			// Set the type and force the browser to download it as the 
 			// last step before beginning to stream the response.
 			httpResponse.setContentType("text/csv");
-			httpResponse.setHeader("Content-Disposition", "attachment; filename=Mobility.csv");
+			httpResponse.setHeader("Content-Disposition", "attachment; filename=\"Mobility.csv\"");
 			
 			// If available, set the token.
 			if(getUser() != null) {

--- a/src/org/ohmage/request/survey/SurveyResponseReadRequest.java
+++ b/src/org/ohmage/request/survey/SurveyResponseReadRequest.java
@@ -1248,10 +1248,10 @@ public final class SurveyResponseReadRequest
 						// Mark it as an attachment.
 						httpResponse.setContentType("text/csv");
 						httpResponse.setHeader(
-								"Content-Disposition", 
-								"attachment; filename=" + 
-									getCampaign().getName() + 
-									".csv");
+								"Content-Disposition",
+								"attachment; filename=\"" +
+									getCampaign().getName() +
+									".csv\"");
 
 						StringBuilder resultBuilder = new StringBuilder();
 						

--- a/src/org/ohmage/request/video/VideoReadRequest.java
+++ b/src/org/ohmage/request/video/VideoReadRequest.java
@@ -136,7 +136,7 @@ public class VideoReadRequest extends UserRequest {
 				
 				httpResponse.setHeader(
 					"Content-Disposition", 
-					"attachment; filename=" + video.getFileName());
+					"attachment; filename=\"" + video.getFileName() + "\"");
 				httpResponse.setHeader(
 					"Content-Length", 
 					new Long(video.getFileSize()).toString());


### PR DESCRIPTION
Chrome doesn't like downloading documents with commas in the filename. It returns an ERR_RESPONSE_HEADERS_MULTIPLE_CONTENT_DISPOSITION error.

According to the HTTP spec, filenames should be double-quoted in the Content-Disposition header and we are not doing that.

https://foocompelsyou.wordpress.com/2012/10/01/the-curious-case-of-chrome-content-disposition-and-the-comma/

https://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1