### PR TITLE
Added a user_id parameter in user_info/read API response

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -3,7 +3,7 @@
   <property file="build.properties"/>
   <property name="library" location="lib"/>
   <property name="app_name" value="ohmage"/>
-  <property name="app_version" value="2.18.1"/>
+  <property name="app_version" value="2.19.0"/>
   <property name="src" location="src"/>
   <property name="test" location="test"/>
   <property name="view" location="view"/>

--- a/src/org/ohmage/query/IUserQueries.java
+++ b/src/org/ohmage/query/IUserQueries.java
@@ -117,6 +117,17 @@ public interface IUserQueries {
 			final String emailAddress,
 			final String registrationId)
 			throws DataAccessException;
+        
+        /**
+	 * Returns id for a user
+	 * 
+	 * @param username The username for which to retrieve the user id.
+	 * 
+	 * @return Returns the string-ed user id
+	 * 
+	 * @throws DataAccessException Thrown if there is an error.
+	 */
+     	public String getUserIdFromUsername(String username) throws DataAccessException;
 
 	/**
 	 * Returns whether or not a user exists.

--- a/src/org/ohmage/query/impl/UserQueries.java
+++ b/src/org/ohmage/query/impl/UserQueries.java
@@ -55,6 +55,12 @@ import org.springframework.transaction.support.DefaultTransactionDefinition;
  * @author John Jenkins
  */
 public class UserQueries extends Query implements IUserQueries {
+        // Returns the id for the user
+        private static final String SQL_GET_USER_ID_WITH_USERNAME = 
+                "SELECT id " +
+                "FROM user " +
+                "WHERE username = ?";
+    
 	// Returns a boolean representing whether or not a user exists
 	private static final String SQL_EXISTS_USER = 
 		"SELECT EXISTS(" +
@@ -903,6 +909,36 @@ public class UserQueries extends Query implements IUserQueries {
 		}
 		catch(TransactionException e) {
 			throw new DataAccessException("Error while attempting to rollback the transaction.", e);
+		}
+	}
+        
+	/**
+	 * Returns the user's id
+	 * 
+	 * @param username The user's username.
+	 * 
+	 * @return The user's id
+	 * 
+	 * @throws DataAccessException There was an error.
+	 */
+        @Override
+	public String getUserIdFromUsername(String username)
+			throws DataAccessException {
+
+		try {
+			return getJdbcTemplate().queryForObject(
+					SQL_GET_USER_ID_WITH_USERNAME, 
+					new Object[] { username }, 
+					String.class
+				);
+		}
+		catch(org.springframework.dao.DataAccessException e) {
+			throw new DataAccessException(
+					"Error executing SQL '" +
+						SQL_GET_USER_ID_WITH_USERNAME +
+						"' with parameter: " +
+						"%" + username + "%",
+					e);
 		}
 	}
 	

--- a/src/org/ohmage/request/user/UserInfoReadRequest.java
+++ b/src/org/ohmage/request/user/UserInfoReadRequest.java
@@ -65,6 +65,7 @@ public class UserInfoReadRequest extends UserRequest {
 	
 	private String gUsername;
 	private UserSummary result = null;
+        private String _userId = "";
 	
 	/**
 	 * Creates a new user info read request.
@@ -140,6 +141,15 @@ public class UserInfoReadRequest extends UserRequest {
 			e.failRequest(this);
 			e.logException(LOGGER);
 		}
+                try {			
+                        _userId = UserServices.instance().getUserIdFromUsername(gUsername);
+		}
+		catch(ServiceException e) {
+                        // Do not fail the request if user ID was not found
+			// e.failRequest(this);
+			e.logException(LOGGER);
+		}
+
 	}
 
 	/**
@@ -154,7 +164,11 @@ public class UserInfoReadRequest extends UserRequest {
 		
 		if(result != null) {
 			try {
-				jsonResult.put(gUsername, result.toJsonObject());
+                                JSONObject result_json = result.toJsonObject( );
+                                if( !_userId.equals( "" ) ) {
+                                    result_json.put( "user_id", _userId );                                
+                                }
+				jsonResult.put(gUsername, result_json);
 			}
 			catch(JSONException e) {
 				LOGGER.error("There was an error building the JSONObject result.", e);

--- a/src/org/ohmage/service/UserServices.java
+++ b/src/org/ohmage/service/UserServices.java
@@ -1896,6 +1896,25 @@ public final class UserServices {
 			throw new ServiceException(e);
 		}
 	}
+        
+        /**
+	 * Retrieves the user id for a username
+	 * 
+	 * @param username The username.
+	 * 
+	 * @return The user's id
+	 * 
+	 */
+	public String getUserIdFromUsername(
+			final String username) throws ServiceException {
+		
+		try {
+			return userQueries.getUserIdFromUsername(username);
+		}
+		catch (DataAccessException e) {
+			throw new ServiceException(e);
+		}
+	}
 	
 	/**
 	 * Updates a user's account information.
@@ -2313,5 +2332,7 @@ public final class UserServices {
 		}
 
 	}
+        
+        
 	
 }


### PR DESCRIPTION
This is to allow client applications to have a numeric id associated with a user account.

To be used by the [pam_ohmage](https://github.com/mobilizingcs/pam_ohmage) module. This is one of the solutions to [pam_ohmage #3](https://github.com/mobilizingcs/pam_ohmage/issues/3). 

However, I am not sure if ohmage should be doing this. I cannot see how this change would break anything within ohmage or any of the existing client application.

Is there a reason ohmage did not return the numeric user ids?