### PR TITLE
fixup the pw.mobilizingcs.org url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM tomcat:7
+FROM tomcat:7-jdk8-openjdk
 MAINTAINER Steve Nolen <technolengy@gmail.com>
 # Report issues here: https://github.com/ohmage/server
 
 RUN set -x \
     && export DEBIAN_FRONTEND=noninteractive \
     && apt-get update \
-    && apt-get install --no-install-recommends -y openjdk-7-jdk ant ant-optional netcat git\
+    && apt-get install --no-install-recommends -y ant ant-optional netcat git\
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /usr/local/tomcat/webapps/ROOT \
@@ -18,7 +18,7 @@ RUN set -x \
  
 #### download flyway (ohmage doesn't do migrations) ####
 WORKDIR /flyway
-ENV FLYWAY_TGZ_URL http://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/3.2.1/flyway-commandline-3.2.1.tar.gz
+ENV FLYWAY_TGZ_URL https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/4.2.0/flyway-commandline-4.2.0-linux-x64.tar.gz
 RUN set -x \
     && curl -fSL "$FLYWAY_TGZ_URL" -o flyway.tar.gz \
     && tar -xvf flyway.tar.gz --strip-components=1 \

--- a/build.xml
+++ b/build.xml
@@ -3,7 +3,7 @@
   <property file="build.properties"/>
   <property name="library" location="lib"/>
   <property name="app_name" value="ohmage"/>
-  <property name="app_version" value="2.18.1"/>
+  <property name="app_version" value="2.18.2"/>
   <property name="src" location="src"/>
   <property name="test" location="test"/>
   <property name="view" location="view"/>

--- a/src/org/ohmage/request/user/UserSetupRequest.java
+++ b/src/org/ohmage/request/user/UserSetupRequest.java
@@ -463,7 +463,7 @@ public class UserSetupRequest extends UserRequest {
 	public String getRandomPassword() throws ServiceException {
 		try {
 			// Create the URL.
-			URL url = new URL("http://pw.mobilizingcs.org/password/simple/");
+			URL url = new URL("https://pw.mobilizingcs.org/password");
 			// Connect to the URL.
 			HttpURLConnection connection =
 				(HttpURLConnection) url.openConnection();


### PR DESCRIPTION
tweak the docker build to use openjdk8
bump the version

relates to #902 

This is a vaguely risky change given it shifts to openjdk8 over openjdk7 (which has been deprecated for quite some time).